### PR TITLE
Poprawienie robienia kopii zapasowej i poprawki w README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,36 @@
 Skrypt wspierający pracę z systemem MINIX 2.0.3 w środowisku emulatora qemu uruchamianego pod systemem Linux.
 
-- Objaśnienia wstępne
-	System MINIX 2.0.3 dostępny w postaci obrazu (.img) stanowi pełny, funkcjonujący system operacyjny, który można zainstalować na swoim komputerze. Jego obsługa jest jednak dość trudna, a funkcje ograniczone. Dodatkowo podczas modyfikacji jądra systemu istnieje możliwość sprowadzenia go do postaci niedziałającej, co zmuszałoby do ciągłych reinstalacji, utraty postępu i rozpoczynania od początku.
+### Objaśnienia wstępne
+System MINIX 2.0.3 dostępny w postaci obrazu (.img) stanowi pełny, funkcjonujący system operacyjny, który można zainstalować na swoim komputerze. Jego obsługa jest jednak dość trudna, a funkcje ograniczone. Dodatkowo podczas modyfikacji jądra systemu istnieje możliwość sprowadzenia go do postaci niedziałającej, co zmuszałoby do ciągłych reinstalacji, utraty postępu i rozpoczynania od początku.
 	
-	Dlatego też system MINIX uruchamiany jest poprzez emulator qemu, który po podaniu nazwy wirtualnego dysku / obrazu emuluje działanie komputera. W przypadku unieruchomienia systemu MINIX - można rozpocząć od działającej kopii.
+Dlatego też system MINIX uruchamiany jest poprzez emulator qemu, który po podaniu nazwy wirtualnego dysku / obrazu emuluje działanie komputera. W przypadku unieruchomienia systemu MINIX - można rozpocząć od działającej kopii.
 	
-- Cel skryptu
-	Skrypt powstał w celu jeszcze większej automatyzacji i uproszczenia pracy z systemem MINIX. Skrypt umożliwia między innymi:
-	- Automatyczne pobranie czystego obrazu MINIX 2.0.3 używanego w trakcie zajęć
-	- Zamontowanie aktywnego obrazu w katalogu roboczym (można przeglądać i edytować pliki wewnątrz obrazu za pośrednictwem Linux'a)
-	- Uruchomienie emulatora qemu i automatyczne stworzenie kopii zapasowej obrazu
-	- Przywrócenie kopii zapasowej obrazu
-	- Uruchomienie edytora gedit jako root
+### Cel skryptu
 
-- Instrukcja pracy ze skryptem (w środowisku systemu Ubuntu Linux 14.04)
-	1. Skrypt należy pobrać i zapisać w dowolnym katalogu (na przykład nowym katalogu na pulpicie) pod wybraną nazwą. Przyjęte tu 'minix.sh'
-	2. Uruchomić terminal i przejść do katalogu w którym znajduje się skrypt
-	3. Upewnić się, że skrypt ma flagę umożliwiającą wykonanie, jeśli nie, nadać ją poleceniem 'chmod +x minix.sh'
+Skrypt powstał w celu jeszcze większej automatyzacji i uproszczenia pracy z systemem MINIX. Skrypt umożliwia między innymi:
+- Automatyczne pobranie czystego obrazu MINIX 2.0.3 używanego w trakcie zajęć
+- Zamontowanie aktywnego obrazu w katalogu roboczym (można przeglądać i edytować pliki wewnątrz obrazu za pośrednictwem Linux'a)
+- Uruchomienie emulatora qemu i automatyczne stworzenie kopii zapasowej obrazu
+- Przywrócenie kopii zapasowej obrazu
+- Uruchomienie edytora gedit jako root
+
+### Instrukcja pracy ze skryptem (w środowisku systemu Ubuntu Linux 14.04)
+1. Skrypt należy pobrać i zapisać w dowolnym katalogu (na przykład nowym katalogu na pulpicie) pod wybraną nazwą. Przyjęte tu 'minix.sh'
+2. Uruchomić terminal i przejść do katalogu w którym znajduje się skrypt
+3. Upewnić się, że skrypt ma flagę umożliwiającą wykonanie, jeśli nie, nadać ją poleceniem 'chmod +x minix.sh'
 	
-	4. Skrypt musi być uruchamiany z prawami root'a (potrzebne polecenia mount / umount) - należy go uruchomić na przykład poprzez 'sudo ./minix.sh'
-		Na tym etapie skrypt sprawdzi istnienie czystego obrazu minixa (minix203.img.ori) w swoim katalogu. Jeśli taki plik nie istnieje, zostanie automatycznie pobrany i zapisany pod tą nazwą. Skrypt utworzy katalog roboczy minix_usr, w którym widoczne będą pliki z obrazu. Skrypt sprawdzi istnienie obrazu roboczego (tego, nad którym aktualnie pracujemy), jeśli takowy nie istniał - stanie się nim czysty obraz.
-		Aby nie doprowadzić do błędów - obraz musi zostać odmontowany kiedy uruchamiany jest emulator albo tworzona kopia zapasowa. Dzieję się to automatycznie, jednak w tym czasie żadne pliki znajdujące się w folderze minix_usr nie mogą być otwarte. W przypadku zaistnienia takiej sytuacji - skrypt pokaże błąd.
-	5. Kiedy wyświetli się menu - pliki minixa dostępne są w katalogu minix_usr i jesteśmy gotowi do pracy
-		Możemy teraz rozpocząć edycję systemu. Należy zauważyć, że pliki zamontowane w katalogu minix_usr mają jako właściciela root'a - tylko root może je wyedytować. Dlatego też powstała funkcja uruchomienia edytora tekstu gedit jako root. Edytor uruchomiony jako root ma możliwość edycji plików w katalogu minix_usr
-	6. Po zakończeniu wprowadzania pierwszej serii zmian - można przystąpić do uruchomienia systemu. Należy zamknąć wszystkie okna edytora, terminale otwarte wewnątrz minix_usr. Wybierając pozycję 'Uruchom minixa' - obraz zostanie odmontowany. Następnie zostanie stworzona jego kopia zapasowa (nazwa zawierająca datę utworzenia) i obraz zostanie uruchomiony w środowisku qemu. Po zamknięciu emulatora - obraz zostanie ponownie zamontowany w katalogu minix_usr - można powrócić do jego edycji.
+4. Skrypt musi być uruchamiany z prawami root'a (potrzebne polecenia `mount` / `umount`) - należy go uruchomić na przykład poprzez `sudo ./minix.sh`
+	Na tym etapie skrypt sprawdzi istnienie czystego obrazu minixa (minix203.img.ori) w swoim katalogu. Jeśli taki plik nie istnieje, zostanie automatycznie pobrany i zapisany pod tą nazwą. Skrypt utworzy katalog roboczy `minix_usr`, w którym widoczne będą pliki z obrazu. Skrypt sprawdzi istnienie obrazu roboczego (tego, nad którym aktualnie pracujemy), jeśli takowy nie istniał - stanie się nim czysty obraz.
+	Aby nie doprowadzić do błędów - obraz musi zostać odmontowany kiedy uruchamiany jest emulator albo tworzona kopia zapasowa. Dzieję się to automatycznie, jednak w tym czasie żadne pliki znajdujące się w folderze minix_usr nie mogą być otwarte. W przypadku zaistnienia takiej sytuacji - skrypt pokaże błąd.
+5. Kiedy wyświetli się menu - pliki minixa dostępne są w katalogu `minix_usr` i jesteśmy gotowi do pracy
+	Możemy teraz rozpocząć edycję systemu. Należy zauważyć, że pliki zamontowane w katalogu `minix_usr` mają jako właściciela root'a - tylko root może je wyedytować. Dlatego też powstała funkcja uruchomienia edytora tekstu gedit jako root. Edytor uruchomiony jako root ma możliwość edycji plików w katalogu `minix_usr`
+6. Po zakończeniu wprowadzania pierwszej serii zmian - można przystąpić do uruchomienia systemu. Należy zamknąć wszystkie okna edytora, terminale otwarte wewnątrz `minix_usr`. Wybierając pozycję 'Uruchom minixa' - obraz zostanie odmontowany. Następnie zostanie stworzona jego kopia zapasowa (nazwa zawierająca datę utworzenia) i obraz zostanie uruchomiony w środowisku qemu. Po zamknięciu emulatora - obraz zostanie ponownie zamontowany w katalogu `minix_usr` - można powrócić do jego edycji.
 	
-	7. W przypadku gdy obecnie edytowany obraz stanie się martwy (na przykład skompilowane jądro nie uruchamia się) możliwe jest przywrócenie poprzedniej wersji. Po wybraniu odpowiedniej wersji - skrypt skopiuje ją jako roboczą. Możliwe jest też rozpoczęcie od czystej wersji systemu.
+7. W przypadku gdy obecnie edytowany obraz stanie się martwy (na przykład skompilowane jądro nie uruchamia się) możliwe jest przywrócenie poprzedniej wersji. Po wybraniu odpowiedniej wersji - skrypt skopiuje ją jako roboczą. Możliwe jest też rozpoczęcie od czystej wersji systemu. W folderze `backups/auto/` przechowywane jest do 5-ciu automatycznych kopii, jeżeli nadamy naszej kopii własną nazwę to zostanie ona zachowana i nie zostanie usunięta.
 	
-	8. Po zakończonej pracy istnieje możliwość:
-		- Wyeksportowania zmian do archiwum. Skrypt porówna oryginalny i obecny obraz pod kątem zmian - wszystkie zmienione pliki zostaną spakowane do archiwum .zip, którego nazwa zostanie wyświetlona. Archiwum zostanie utworzone w tym katalogu, co skrypt. Przy tworzeniu archiwum pomijane są pliki wykonywalne i obiekty. Do uruchomienia tej funkcji - system macierzysty (Linux) potrzebuje dostępnego polecenia zip.
-		- Przeniesienia obecnego obrazu na nośnik zewnętrzny (na przykład pendrive). Skrypt zakłada, że system automatycznie montuje pendrive'y w katalogu /media/?/?. W przypadku gdy system tego nie robi - konieczne jest zamontowanie ręczne. 
+8. Po zakończonej pracy istnieje możliwość:
+	- Wyeksportowania zmian do archiwum. Skrypt porówna oryginalny i obecny obraz pod kątem zmian - wszystkie zmienione pliki zostaną spakowane do archiwum .zip, którego nazwa zostanie wyświetlona. Archiwum zostanie utworzone w tym katalogu, co skrypt. Przy tworzeniu archiwum pomijane są pliki wykonywalne i obiekty. Do uruchomienia tej funkcji - system macierzysty (Linux) potrzebuje dostępnego polecenia `zip`.
+	- Przeniesienia obecnego obrazu na nośnik zewnętrzny (na przykład pendrive). Skrypt zakłada, że system automatycznie montuje pendrive'y w katalogu /media/?/?. W przypadku gdy system tego nie robi - konieczne jest zamontowanie ręczne. 
 
 
 

--- a/minix.sh
+++ b/minix.sh
@@ -77,6 +77,11 @@ image_create_backup()
 		BACKUP_FILENAME="./backups/${MINIX_CUR_NAME}_${BACKUP_TIMESTAMP}"
 		cp -v $MINIX_CUR_NAME $BACKUP_FILENAME
 	fi
+	backups_num=`ls -1 ./backups/ | wc -l`
+	if [ "$backups_num" -g 5 ]
+	then
+		find ./backups/* | head -n 1 | xargs rm
+	fi
 	
 	echo "-> Utworzono backup obecnej wersji pod nazwą $BACKUP_FILENAME"
 }

--- a/minix.sh
+++ b/minix.sh
@@ -69,7 +69,7 @@ image_create_named_backup()
 {
 	if ! test -d ./backups/
 	then
-		mkdir -m 777 backups >/dev/null
+		mkdir backups >/dev/null
 	fi
 	if test -f $MINIX_CUR_NAME
 	then
@@ -100,7 +100,7 @@ image_create_backup()
 {
 	if ! test -d ./backups/auto
 	then
-		mkdir -m 777 backups/auto >/dev/null
+		mkdir backups/auto >/dev/null
 	fi
 	if test -f $MINIX_CUR_NAME
 	then

--- a/minix.sh
+++ b/minix.sh
@@ -78,7 +78,7 @@ image_create_backup()
 		cp -v $MINIX_CUR_NAME $BACKUP_FILENAME
 	fi
 	backups_num=`ls -1 ./backups/ | wc -l`
-	if [ "$backups_num" -g 5 ]
+	if [ "$backups_num" -gt 5 ]
 	then
 		find ./backups/* | head -n 1 | xargs rm
 	fi

--- a/minix.sh
+++ b/minix.sh
@@ -64,28 +64,56 @@ run_minix()
 }
 
 # Backupuje aktualny obraz
+# Tworzona jest kopia z nazwą użytkownika
+image_create_named_backup()
+{
+	if ! test -d ./backups/
+	then
+		mkdir -m 777 backups >/dev/null
+	fi
+	if test -f $MINIX_CUR_NAME
+	then
+		read -p 'Wpisz nazwe kopii: ' BACKUP_NAME
+		if [ -z $BACKUP_NAME ]
+			then
+			image_create_backup
+			return
+		else
+		if [ -e ./backups/$BACKUP_NAME ]
+		then
+			echo "!!! Taka nazwa juz istnije !!!"	
+			echo "!!! Nie utworzono kopii !!!"
+			return
+		else
+			BACKUP_FILENAME="./backups/$BACKUP_NAME"		
+		cp -v $MINIX_CUR_NAME $BACKUP_FILENAME
+		echo "-> Utworzono backup obecnej wersji pod nazwą $BACKUP_FILENAME"
+		fi
+		fi
+	fi
+	
+	
+}
+# Backupuje aktualny obraz
 # Tworzona jest kopia z nazwą zawierającą aktualną datę
 image_create_backup()
 {
-	if ! test -f ./backups/
+	if ! test -d ./backups/auto
 	then
-		mkdir backups
+		mkdir -m 777 backups/auto >/dev/null
 	fi
 	if test -f $MINIX_CUR_NAME
 	then
 		BACKUP_TIMESTAMP=`$CREATE_DATE_CMD`
-		BACKUP_FILENAME="./backups/${MINIX_CUR_NAME}_${BACKUP_TIMESTAMP}"
-		cp -v $MINIX_CUR_NAME $BACKUP_FILENAME
+		TEMP_BACKUP_FILENAME="./backups/auto/${MINIX_CUR_NAME}_${BACKUP_TIMESTAMP}"
+		cp -v $MINIX_CUR_NAME $TEMP_BACKUP_FILENAME
 	fi
-	backups_num=`ls -1 ./backups/ | wc -l`
-	if [ "$backups_num" -g 5 ]
+	backups_num=`ls -1 ./backups/auto/ | wc -l`
+	if [ "$backups_num" -gt 5 ]
 	then
-		find ./backups/* | head -n 1 | xargs rm
+		find ./backups/auto/* | head -n 1 | xargs rm
 	fi
-	
-	echo "-> Utworzono backup obecnej wersji pod nazwą $BACKUP_FILENAME"
 }
-
 # Zamontuj obraz minixa w katalogu roboczym
 # Działanie qemu kiedy obraz jest zamontowany jest (dla mnie) nieznane - po zmianach odmontowuję obraz
 mount_image()
@@ -155,7 +183,7 @@ do
 			# Odmintuj obraz, aby zapisać zmiany
 			umount_image
 			# Stwórz kopię
-			image_create_backup
+			image_create_named_backup
 			# Zamontuj z powrotem obraz do pracy
 			mount_image
 			;;
@@ -181,7 +209,7 @@ do
 		"4")
 			# Lista wszystkich obrazów które mogą zostać przywrócone
 			CANCEL_NAME='Anuluj'
-			FILES_AVAILIBLE=`ls -t ./backups/${MINIX_CUR_NAME}_*`
+			FILES_AVAILIBLE=`ls -t ./backups/`
 			
 			# Super polecenie select oszczędza kupę roboty - wyświetla listę i pozwala wybrać
 			select FILE_NAME in $CANCEL_NAME $FILES_AVAILIBLE

--- a/minix.sh
+++ b/minix.sh
@@ -73,7 +73,7 @@ image_create_named_backup()
 	fi
 	if test -f $MINIX_CUR_NAME
 	then
-		read -p 'Wpisz nazwe kopii: ' BACKUP_NAME
+		read -p 'Wpisz nazwe kopii (nie podawaj nazwy, jeżeli chcesz, aby kopia miała automatycznie przydzielaną nazwę): ' BACKUP_NAME
 		if [ -z $BACKUP_NAME ]
 			then
 			image_create_backup
@@ -113,6 +113,7 @@ image_create_backup()
 
 	if [ "$backups_num" -gt 5 ]
 	then
+		echo "-> Usunięto starą kopię zapasową o nazwie: `find ./backups/auto/* | head -n 1`"
 		find ./backups/auto/* | head -n 1 | xargs rm
 	fi
 }
@@ -211,7 +212,7 @@ do
 		"4")
 			# Lista wszystkich obrazów które mogą zostać przywrócone
 			CANCEL_NAME='Anuluj'
-			FILES_AVAILIBLE=`ls -t ./backups/`
+			FILES_AVAILIBLE=`find ./backups/* -type f`
 			
 			# Super polecenie select oszczędza kupę roboty - wyświetla listę i pozwala wybrać
 			select FILE_NAME in $CANCEL_NAME $FILES_AVAILIBLE

--- a/minix.sh
+++ b/minix.sh
@@ -67,10 +67,14 @@ run_minix()
 # Tworzona jest kopia z nazwą zawierającą aktualną datę
 image_create_backup()
 {
+	if ! test -f ./backups/
+	then
+		mkdir backups
+	fi
 	if test -f $MINIX_CUR_NAME
 	then
 		BACKUP_TIMESTAMP=`$CREATE_DATE_CMD`
-		BACKUP_FILENAME="${MINIX_CUR_NAME}_${BACKUP_TIMESTAMP}"
+		BACKUP_FILENAME="./backups/${MINIX_CUR_NAME}_${BACKUP_TIMESTAMP}"
 		cp -v $MINIX_CUR_NAME $BACKUP_FILENAME
 	fi
 	
@@ -172,7 +176,7 @@ do
 		"4")
 			# Lista wszystkich obrazów które mogą zostać przywrócone
 			CANCEL_NAME='Anuluj'
-			FILES_AVAILIBLE=`ls -t ${MINIX_CUR_NAME}_*`
+			FILES_AVAILIBLE=`ls -t ./backups/${MINIX_CUR_NAME}_*`
 			
 			# Super polecenie select oszczędza kupę roboty - wyświetla listę i pozwala wybrać
 			select FILE_NAME in $CANCEL_NAME $FILES_AVAILIBLE


### PR DESCRIPTION
- od teraz kopie zapasowe są zapisywane w folderze `backups` i możemy im nadawać własne nazwy
- standardowe (te bez ręcznie nadanej nazwy) i automatyczne kopie zapasowe są zapoisywane w `./backups/auto/`
- najstarsze kopie z folderu `./backups/auto/' są usuwane podczas zapisywania, jeżeli w tym folderze jest więcej niż 5 kopii
- poprawki w `REDME.md` w celu poprawienia czytelności oraz dodanie informacji o kopiach zapasowych
